### PR TITLE
docs: restore repo role map

### DIFF
--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -1,0 +1,40 @@
+# REPO MAP — MIRRORNODE SYSTEM
+
+## Declared Repositories
+
+### MIRRORNODE-CORE-HUB
+Role: Organization-level governance and coordination record
+Source of truth for:
+- canonical source mapping
+- cross-repo governance records
+- audit milestones
+- system-level issue anchors
+- operator decision records
+
+### mirrornode
+Role: Monorepo, orchestration root, and active runtime work surface
+Source of truth for:
+- repo-local runtime code
+- service implementations currently housed in this repo
+- repo-local system contracts
+- Oracle runtime PRs while Oracle remains implemented here
+
+## Oracle Rule
+Oracle governance language is declared through CORE-HUB and REPO_MAP.
+Oracle runtime truth lives where the runnable Oracle service lives.
+
+As of 2026-06-24:
+- Oracle runtime PR #7 lives in mirrornode.
+- Any future migration to CORE-HUB must be explicit.
+
+## Repo-of-Truth Rule
+Governance questions -> CORE-HUB
+Repo role questions -> REPO_MAP.md
+Runtime questions -> the repo containing the runnable service
+Ambiguous questions -> Operator decision
+
+## Last confirmed
+2026-06-24
+
+## Confirmed by
+Operator


### PR DESCRIPTION
Restores REPO_MAP.md as the cross-repo role anchor for MIRRORNODE.

This resolves the missing-reference portion of G1 and prepares the repo-of-truth decision for G2.

Key declarations:
- CORE-HUB remains organization-level governance and coordination record.
- mirrornode remains monorepo/orchestration root and current Oracle runtime work surface.
- Runtime truth lives where the runnable service lives.
- Ambiguity escalates to Operator decision.

No runtime code changes.