### PR TITLE
chore: ignore local env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ logs/
 .env.keys
 *.backup
 keypairs-backup.json
+.env.production.local
+.env.development.local

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ logs/
 # Security - NEVER COMMIT
 .env
 .env.*
+!.env.example
+!.env.*.example
+!.env.template
+!.env.*.template
 .env.keys
 *.backup
 keypairs-backup.json


### PR DESCRIPTION
Narrows local env ignores after Vercel CLI generated .env.local during Oracle env provisioning. Avoids broad .env* ignore so env templates remain visible to git.