### PR TITLE
docs(profile): align public surface and canon authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ The canonical monorepo for the MIRRORNODE distributed AI orchestration system.
 ## 🌐 Canonical Deployment URLs
 
 ### Production Surfaces
-- **MIRRORNODE Public HUD**: [https://mirrornode-qsu3fnwh1-inphase.vercel.app/](https://mirrornode-qsu3fnwh1-inphase.vercel.app/)  
-  Shared space for agents-in-repos work, refactors, fixes, HUD iteration, and "make it work" sessions.
+- **Parallax Front-of-House**: [https://parallax.mirrornode.xyz](https://parallax.mirrornode.xyz)  
+  Public MIRRORNODE surface for architecture modeling, risk-first positioning, and the Osiris Audit revenue path.
+
+- **Osiris Audit v1**: [https://mirrornode.xyz/audit](https://mirrornode.xyz/audit)  
+  Paid manual structural audit offer for AI-system posture review.
 
 - **Osiris Operator Console**: [https://osiris-mu.vercel.app/](https://osiris-mu.vercel.app/)  
   Operator console for MIRRORNODE Node 4, triadic lattice operator view.
@@ -22,6 +25,7 @@ The canonical monorepo for the MIRRORNODE distributed AI orchestration system.
 
 ### GitHub Organization
 - **Main Repository**: [https://github.com/mirrornode/mirrornode](https://github.com/mirrornode/mirrornode)
+- **Parallax Front-of-House**: [https://github.com/mirrornode/mirrornode-parallax](https://github.com/mirrornode/mirrornode-parallax)
 - **Osiris UI**: [https://github.com/mirrornode/osiris](https://github.com/mirrornode/osiris)
 - **Python Bridge**: [https://github.com/mirrornode/mirrornode-py](https://github.com/mirrornode/mirrornode-py)
 
@@ -133,8 +137,12 @@ Each kit is a thin client: all intelligence is imported from `mirrornode-core` v
 
 ## 📦 Shipped Products
 
-- **Osiris Audit v1** — Advisory, offline security audit tool  
-  See: `mirrornode-osiris/`
+- **Parallax Front-of-House** — Public architecture-modeling and risk-signaling surface  
+  Live: [https://parallax.mirrornode.xyz](https://parallax.mirrornode.xyz)  
+  Repo: [mirrornode/mirrornode-parallax](https://github.com/mirrornode/mirrornode-parallax)
+
+- **Osiris Audit v1** — Manual structural audit for AI-system posture review  
+  Offer: [https://mirrornode.xyz/audit](https://mirrornode.xyz/audit)
 
 ---
 
@@ -164,14 +172,15 @@ Global integration tests, contract tests, and cross-module test harnesses.
 - [ ] Bridge loop operational
 - [ ] Canonical HUD actions wired
 - [ ] Inventory "codes" documented
-- [ ] GitHub ↔ Vercel deployment confirmed
+- [x] GitHub ↔ Vercel deployment confirmed for Parallax
 - [ ] MIRRORNODE Ops documentation complete
 
 ---
 
 ## 🔗 Related Repositories
 
-- **osiris**: [github.com/mirrornode/osiris](https://github.com/mirrornode/osiris) — Operator HUD (deployed at osiris-mu.vercel.app)
+- **mirrornode-parallax**: [github.com/mirrornode/mirrornode-parallax](https://github.com/mirrornode/mirrornode-parallax) — Parallax front-of-house, deployed at [parallax.mirrornode.xyz](https://parallax.mirrornode.xyz)
+- **osiris**: [github.com/mirrornode/osiris](https://github.com/mirrornode/osiris) — Operator HUD, deployed at osiris-mu.vercel.app
 - **osiris-ui**: Private repository for advanced Osiris UI components
 - **mirrornode-py**: [github.com/mirrornode/mirrornode-py](https://github.com/mirrornode/mirrornode-py) — Python FastAPI bridge service
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # MIRRORNODE Monorepo
 
-The canonical monorepo for the MIRRORNODE distributed AI orchestration system.
+Execution monorepo and operational surface for the MIRRORNODE distributed AI orchestration system.
 
-## 🌐 Canonical Deployment URLs
+Canonical governance, promotion records, and source-of-truth decisions live in [MIRRORNODE-CORE-HUB](https://github.com/mirrornode/MIRRORNODE-CORE-HUB). This repo carries implementation scaffolding, product-facing links, local development notes, and execution evidence.
+
+## 🌐 Deployment URLs
 
 ### Production Surfaces
 - **Parallax Front-of-House**: [https://parallax.mirrornode.xyz](https://parallax.mirrornode.xyz)  
@@ -25,6 +27,7 @@ The canonical monorepo for the MIRRORNODE distributed AI orchestration system.
 
 ### GitHub Organization
 - **Main Repository**: [https://github.com/mirrornode/mirrornode](https://github.com/mirrornode/mirrornode)
+- **Canonical Governance**: [https://github.com/mirrornode/MIRRORNODE-CORE-HUB](https://github.com/mirrornode/MIRRORNODE-CORE-HUB)
 - **Parallax Front-of-House**: [https://github.com/mirrornode/mirrornode-parallax](https://github.com/mirrornode/mirrornode-parallax)
 - **Osiris UI**: [https://github.com/mirrornode/osiris](https://github.com/mirrornode/osiris)
 - **Python Bridge**: [https://github.com/mirrornode/mirrornode-py](https://github.com/mirrornode/mirrornode-py)
@@ -33,7 +36,7 @@ The canonical monorepo for the MIRRORNODE distributed AI orchestration system.
 
 ## 🏗️ System Architecture
 
-This repository contains the full architecture for MIRRORNODE's recursive intelligence framework, including:
+This repository contains implementation scaffolding and operational architecture surfaces for MIRRORNODE, including:
 
 ### Core Layers
 
@@ -55,7 +58,9 @@ Each agent is a first-class node with its own role and configuration.
 - **claude/** — Narrative, spec refinement, interface clarity.  
 - **grok/** — Diagramming, structural insight, architectural reflection.
 
-### Node Topology (Canonical Lattice)
+### Node Topology (Operational Snapshot)
+
+This table reflects the current monorepo-facing operational snapshot. Canonical node authority and promotions are governed by CORE-HUB.
 
 | Node ID | Name | Role | Status |
 |---------|------|------|--------|
@@ -179,6 +184,7 @@ Global integration tests, contract tests, and cross-module test harnesses.
 
 ## 🔗 Related Repositories
 
+- **MIRRORNODE-CORE-HUB**: [github.com/mirrornode/MIRRORNODE-CORE-HUB](https://github.com/mirrornode/MIRRORNODE-CORE-HUB) — Canon, governance, schemas, and promotion register
 - **mirrornode-parallax**: [github.com/mirrornode/mirrornode-parallax](https://github.com/mirrornode/mirrornode-parallax) — Parallax front-of-house, deployed at [parallax.mirrornode.xyz](https://parallax.mirrornode.xyz)
 - **osiris**: [github.com/mirrornode/osiris](https://github.com/mirrornode/osiris) — Operator HUD, deployed at osiris-mu.vercel.app
 - **osiris-ui**: Private repository for advanced Osiris UI components
@@ -186,9 +192,9 @@ Global integration tests, contract tests, and cross-module test harnesses.
 
 ---
 
-**This repository represents the single source of truth for MIRRORNODE.**
+**This repository is an execution monorepo and operational surface.**
 
-If a path or file is not defined here, it is not canonical.
+If this README conflicts with a ratified CORE-HUB artifact, the CORE-HUB artifact governs until this repository is updated.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the outdated public HUD deployment link with the canonical Parallax front-of-house URL.
- Adds Osiris Audit v1 as the paid offer path.
- Adds the Parallax repo and live domain to the profile README.
- Downgrades this repository from "single source of truth" language to execution monorepo / operational surface language.
- Points canonical governance, promotions, and source-of-truth decisions to `mirrornode/MIRRORNODE-CORE-HUB`.
- Marks GitHub <-> Vercel deployment confirmed for Parallax.

## Governance posture

This is a docs/profile authority correction only. It does not change runtime architecture, canon authority, or deployment configuration. CORE-HUB remains the governed canon and promotion register; this repo is an execution surface that should inherit and reflect CORE-HUB decisions.

## Validation

- PR #23 in `MIRRORNODE-CORE-HUB` was merged first, establishing the public authority boundary.
- README now links CORE-HUB near the top and in related repositories.
- Removed the conflicting claim that `mirrornode/mirrornode` is the single source of truth for all MIRRORNODE.
- Preserved the Parallax and Osiris public-surface updates already present in this PR.