### PR TITLE
fix: remove conflicting Vercel builds config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,6 @@
 {
   "version": 2,
   "regions": ["iad1"],
-  "builds": [{ "src": "api/index.py", "use": "@vercel/python" }],
   "routes": [{ "src": "/(.*)", "dest": "api/index.py" }],
   "functions": {
     "api/index.py": {


### PR DESCRIPTION
## Summary

- Removes the legacy root `builds` array from `vercel.json`.
- Keeps the existing `functions` configuration for `api/index.py` and its `canon/**` includeFiles rule.
- Leaves `services/oracle/vercel.json` unchanged because it uses `builds` only and does not contain the dual-key conflict.

## Why

Vercel rejects a project config when `functions` and legacy `builds` coexist. The root `vercel.json` had both keys, which matches the connected-project failure reported by Vercel: `The functions property cannot be used in conjunction with the builds property.`

## Validation

- Audited root and per-surface config files:
  - `mirrornode/mirrornode:vercel.json` contains both keys before this patch.
  - `mirrornode/mirrornode:services/oracle/vercel.json` contains `builds` only.
  - `mirrornode/mirrornode-platform:vercel.json` contains neither `builds` nor `functions`.
  - `mirrornode/mirrornode-parallax:vercel.json` contains neither `builds` nor `functions`.
  - `mirrornode/mirrornode-backend` has no root `vercel.json`.
- Patch is intentionally limited to the root config conflict.