### PR TITLE
fix: override stale Vercel project settings

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -5,6 +5,10 @@
 !vercel.json
 !requirements.txt
 
+# Un-ignore static output shim
+!public/
+!public/**
+
 # Un-ignore API entry point
 !api/
 !api/index.py

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MIRRORNODE Spine</title>
+  </head>
+  <body>
+    <main>
+      <h1>MIRRORNODE Spine</h1>
+      <p>Static output shim for Vercel project settings. Runtime requests are routed to the FastAPI spine.</p>
+    </main>
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,8 @@
 {
   "version": 2,
+  "framework": null,
+  "buildCommand": "echo 'No static build required for MIRRORNODE FastAPI spine'",
+  "outputDirectory": "public",
   "regions": ["iad1"],
   "routes": [{ "src": "/(.*)", "dest": "api/index.py" }],
   "functions": {


### PR DESCRIPTION
## Summary

- Forces the root Vercel deployment to Framework Preset `Other` via `framework: null`.
- Overrides stale dashboard build commands with a no-op build command.
- Adds `outputDirectory: public` plus a tiny `public/index.html` shim so projects with stale static output expectations stop failing on missing `public`.
- Updates `.vercelignore` so the `public/` shim is included in Vercel deployments.
- Keeps the FastAPI route intact: all requests continue routing to `api/index.py`.

## Why

After PR #12 removed the `functions` + `builds` conflict, three connected Vercel projects deployed successfully. The remaining failures were distinct project-settings drift:

- `templeofio` was configured as Vite and ran `vite build`, but this repo does not provide Vite in that deploy context.
- `oracle` built `services/oracle` and then failed because Vercel expected a `public` output directory.

Because direct Vercel project-setting mutation is not available through the current tools, this PR applies checked-in Vercel overrides that supersede stale dashboard settings.

## Validation Plan

- Vercel should no longer run `vite build` for `templeofio`.
- Vercel should no longer fail `oracle` on missing `public`.
- Existing green projects (`mirrornode`, `branchofio`, `mirrornode-oracle`) should remain green.
- Canon Gate and Core CI should remain green.

## Notes

This is a deployment shim. The real long-term cleanup is to remove stale duplicate Vercel project connections or set each project's Root Directory / Framework Preset directly in the dashboard.