### PR TITLE
fix: keep env templates visible without weakening secret ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,10 @@ logs/
 # Security - NEVER COMMIT
 .env
 .env.*
+!.env.example
+!.env.*.example
+!.env.template
+!.env.*.template
 .env.keys
 *.backup
 keypairs-backup.json


### PR DESCRIPTION
Replaces the stale/conflicted PR #10 with a clean change from current `main`.

- keeps `.env` and `.env.*` secret files ignored
- explicitly allows `.env.example`, `.env.*.example`, `.env.template`, and `.env.*.template`
- addresses the Codex review finding that the broad `.env.*` rule shadowed the intended template behavior

No credentials or environment values are added.